### PR TITLE
ci: rename actions

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -1,6 +1,6 @@
-name: Node.js CI
+name: npm test on Ubuntu
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -1,6 +1,6 @@
-name: Node.js CI
+name: npm test on OSX
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,6 +1,6 @@
-name: Node.js CI
+name: npm test on Windows
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/test/build.js
+++ b/test/build.js
@@ -6,9 +6,12 @@ const path = require('path');
 readdirSync(__dirname).forEach((item) => {
   const testDir = path.join(__dirname, item);
   if (lstatSync(testDir).isDirectory()) {
-    spawnSync('node-gyp', ['rebuild'], {
+    const child = spawnSync('node-gyp', ['rebuild'], {
       cwd: testDir,
       stdio: 'inherit'
     });
+    if (child.signal || child.status != 0) {
+      process.exit(1);
+    }
   }
 });

--- a/test/index.js
+++ b/test/index.js
@@ -6,8 +6,11 @@ const path = require('path');
 readdirSync(__dirname).forEach((item) => {
   const testDir = path.join(__dirname, item);
   if (lstatSync(testDir).isDirectory()) {
-    spawnSync(process.execPath, [path.join(testDir, 'test.js')], {
+    const child = spawnSync(process.execPath, [path.join(testDir, 'test.js')], {
       stdio: 'inherit'
     });
+    if (child.signal || child.status != 0) {
+      process.exit(1);
+    }
   }
 });


### PR DESCRIPTION
Rename the GitHub workflows to distinguish them by OS.

Signed-off-by: @gabrielschulhof