### PR TITLE
headers: complete separation

### DIFF
--- a/webidl-napi-inl.h
+++ b/webidl-napi-inl.h
@@ -3,76 +3,78 @@
 
 #include "webidl-napi.h"
 
+namespace WebIdlNapi {
+
 template <>
 inline napi_status
-WebIdlNapi::Converter<uint32_t>::ToNative(napi_env env,
-                                          napi_value value,
-                                          uint32_t* result) {
+Converter<uint32_t>::ToNative(napi_env env,
+                              napi_value value,
+                              uint32_t* result) {
   return napi_get_value_uint32(env, value, result);
 }
 
 template <>
 inline napi_status
-WebIdlNapi::Converter<uint32_t>::ToJS(napi_env env,
-                                      const uint32_t& value,
-                                      napi_value* result) {
+Converter<uint32_t>::ToJS(napi_env env,
+                          const uint32_t& value,
+                          napi_value* result) {
   return napi_create_uint32(env, value, result);
 }
 
 template <>
 inline napi_status
-WebIdlNapi::Converter<int32_t>::ToNative(napi_env env,
-                                         napi_value value,
-                                         int32_t* result) {
+Converter<int32_t>::ToNative(napi_env env,
+                             napi_value value,
+                             int32_t* result) {
   return napi_get_value_int32(env, value, result);
 }
 
 template <>
 inline napi_status
-WebIdlNapi::Converter<int32_t>::ToJS(napi_env env,
-                                     const int32_t& value,
-                                     napi_value* result) {
+Converter<int32_t>::ToJS(napi_env env,
+                         const int32_t& value,
+                         napi_value* result) {
   return napi_create_int32(env, value, result);
 }
 
 template <>
 inline napi_status
-WebIdlNapi::Converter<int64_t>::ToNative(napi_env env,
-                                         napi_value value,
-                                         int64_t* result) {
+Converter<int64_t>::ToNative(napi_env env,
+                             napi_value value,
+                             int64_t* result) {
   return napi_get_value_int64(env, value, result);
 }
 
 template <>
 inline napi_status
-WebIdlNapi::Converter<int64_t>::ToJS(napi_env env,
-                                     const int64_t& value,
-                                     napi_value* result) {
+Converter<int64_t>::ToJS(napi_env env,
+                         const int64_t& value,
+                         napi_value* result) {
   return napi_create_int64(env, value, result);
 }
 
 template <>
 inline napi_status
-WebIdlNapi::Converter<double>::ToNative(napi_env env,
-                                        napi_value value,
-                                        double* result) {
+Converter<double>::ToNative(napi_env env,
+                            napi_value value,
+                            double* result) {
   return napi_get_value_double(env, value, result);
 }
 
 template <>
 inline napi_status
-WebIdlNapi::Converter<double>::ToJS(napi_env env,
-                                    const double& value,
-                                    napi_value* result) {
+Converter<double>::ToJS(napi_env env,
+                        const double& value,
+                        napi_value* result) {
   return napi_create_double(env, value, result);
 }
 
 // TODO(gabrielschulhof): DOMString should be utf16, not utf8.
 template <>
 inline napi_status
-WebIdlNapi::Converter<DOMString>::ToNative(napi_env env,
-                                           napi_value str,
-                                           DOMString* result) {
+Converter<DOMString>::ToNative(napi_env env,
+                               napi_value str,
+                               DOMString* result) {
   size_t size;
 
   napi_status status = napi_get_value_string_utf8(env, str, nullptr, 0, &size);
@@ -89,27 +91,87 @@ WebIdlNapi::Converter<DOMString>::ToNative(napi_env env,
 
 template <>
 inline napi_status
-WebIdlNapi::Converter<DOMString>::ToJS(napi_env env,
-                                       const DOMString& str,
-                                       napi_value* result) {
+Converter<DOMString>::ToJS(napi_env env,
+                           const DOMString& str,
+                           napi_value* result) {
   return napi_create_string_utf8(env, str.c_str(), str.size(), result);
 }
 
 template <>
 inline napi_status
-WebIdlNapi::Converter<object>::ToNative(napi_env env,
-                                        napi_value val,
-                                        object* result) {
+Converter<object>::ToNative(napi_env env,
+                            napi_value val,
+                            object* result) {
   *result = static_cast<object>(val);
   return napi_ok;
 }
 
 template <>
 inline napi_status
-WebIdlNapi::Converter<object>::ToJS(napi_env env,
-                                    const object& val,
-                                    napi_value* result) {
+Converter<object>::ToJS(napi_env env, const object& val, napi_value* result) {
   *result = static_cast<napi_value>(val);
   return napi_ok;
 }
+
+inline napi_status PickSignature(napi_env env,
+                                 size_t argc,
+                                 napi_value* argv,
+                                 std::vector<webidl_sig> sigs,
+                                 int* sig_idx) {
+  // Advance through the signatures one argument type at a time and mark those
+  // as non-candidates whose signature does not correspond to the sequence of
+  // argument types found in the actual arguments.
+  for (size_t idx = 0; idx < argc; idx++) {
+    napi_valuetype val_type;
+    napi_status status = napi_typeof(env, argv[idx], &val_type);
+    if (status != napi_ok) return status;
+    for (auto& sig: sigs)
+      if (sig.candidate)
+        if (idx >= sig.sig.size() || sig.sig[idx] != val_type)
+          sig.candidate = false;
+  }
+
+  // If any signatures are left marked as candidates, return the first one. We
+  // do not touch `sig_idx` if we do not find a candidate, so the caller can set
+  // it to -1 to be informed after this call completes that no candidate was
+  // found.
+  for (size_t idx = 0; idx < sigs.size(); idx++)
+    if (sigs[idx].candidate) {
+      *sig_idx = idx;
+      break;
+    }
+
+  return napi_ok;
+}
+
+template <typename T>
+inline napi_status Promise<T>::ToJS(napi_env env,
+                                    const Promise<T>& promise,
+                                    napi_value* result) {
+  return napi_ok;
+}
+
+template <typename T>
+inline napi_status Promise<T>::ToNative(napi_env env,
+                                        napi_value promise,
+                                        Promise<T>* result) {
+  return napi_ok;
+}
+
+template <typename T>
+inline napi_status sequence<T>::ToJS(napi_env env,
+                                     const sequence<T>& seq,
+                                     napi_value* result) {
+  return napi_ok;
+}
+
+
+template <typename T>
+inline napi_status sequence<T>::ToNative(napi_env env,
+                                         napi_value val,
+                                         sequence<T>* result) {
+  return napi_ok;
+}
+
+}  // end of namespace WebIdlNapi
 #endif  // WEBIDL_NAPI_INL_H

--- a/webidl-napi.h
+++ b/webidl-napi.h
@@ -70,72 +70,40 @@ namespace WebIdlNapi {
 template <typename T>
 class Converter {
  public:
-  static inline napi_status ToNative(napi_env env,
-                                     napi_value value,
-                                     T* result);
-  static inline napi_status ToJS(napi_env env,
-                                 const T& value,
-                                 napi_value* result);
+  static napi_status ToNative(napi_env env,
+                              napi_value value,
+                              T* result);
+  static napi_status ToJS(napi_env env,
+                          const T& value,
+                          napi_value* result);
 };
 
 
-static inline napi_status
+static napi_status
 PickSignature(napi_env env,
               size_t argc,
               napi_value* argv,
               std::vector<webidl_sig> sigs,
-              int* sig_idx) {
-
-  // Advance through the signatures one argument type at a time and mark those
-  // as non-candidates whose signature does not correspond to the sequence of
-  // argument types found in the actual arguments.
-  for (size_t idx = 0; idx < argc; idx++) {
-    napi_valuetype val_type;
-    napi_status status = napi_typeof(env, argv[idx], &val_type);
-    if (status != napi_ok) return status;
-    for (auto& sig: sigs)
-      if (sig.candidate)
-        if (idx >= sig.sig.size() || sig.sig[idx] != val_type)
-          sig.candidate = false;
-  }
-
-  // If any signatures are left marked as candidates, return the first one. We
-  // do not touch `sig_idx` if we do not find a candidate, so the caller can set
-  // it to -1 to be informed after this call completes that no candidate was
-  // found.
-  for (size_t idx = 0; idx < sigs.size(); idx++)
-    if (sigs[idx].candidate) {
-      *sig_idx = idx;
-      break;
-    }
-
-  return napi_ok;
-}
+              int* sig_idx);
 
 template <typename T>
 class Promise {
  public:
-  static inline napi_status
-  ToJS(napi_env env, const Promise<T>& promise, napi_value* val) {
-    return napi_ok;
-  }
-  static inline napi_status
-  ToNative(napi_env env, napi_value value, Promise<T>* promise) {
-    return napi_ok;
-  }
+  static napi_status ToJS(napi_env env,
+                          const Promise<T>& promise,
+                          napi_value* val);
+  static napi_status ToNative(napi_env env,
+                              napi_value value,
+                              Promise<T>* promise);
 };
 
-template <typename WebIdlNapiType>
+template <typename T>
 class sequence {
  public:
-  static inline napi_status
-  ToJS(napi_env env, const sequence<WebIdlNapiType>& seq, napi_value* val) {
-    return napi_ok;
-  }
-  static inline napi_status
-  ToNative(napi_env env, napi_value val, sequence<WebIdlNapiType>* result) {
-    return napi_ok;
-  }
+  static napi_status
+  ToJS(napi_env env, const sequence<T>& seq, napi_value* val);
+  static napi_status
+  ToNative(napi_env env, napi_value val, sequence<T>* result);
 };
 
 }  // end of namespace WebIdlNapi


### PR DESCRIPTION
Finish moving implementations out of `webidl-napi.h` into
`webidl-napi-inl.h`.

Signed-off-by: @gabrielschulhof