### PR TITLE
all: implement returning wrapped object from instance method

### DIFF
--- a/test/class/CMakeLists.txt
+++ b/test/class/CMakeLists.txt
@@ -14,7 +14,7 @@ execute_process(
 )
 string(REPLACE "\n" "" REPO_ROOT ${REPO_ROOT})
 add_custom_command(
-    COMMAND node ${REPO_ROOT}/index.js -i class-impl.h -n node_api.h -o ${CMAKE_CURRENT_BINARY_DIR}/class.cc ${CMAKE_CURRENT_SOURCE_DIR}/class.idl
+    COMMAND node ${REPO_ROOT}/index.js -i class-impl.h -o ${CMAKE_CURRENT_BINARY_DIR}/class.cc ${CMAKE_CURRENT_SOURCE_DIR}/class.idl
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/class.idl ${REPO_ROOT}/index.js
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/class.cc
     COMMENT "Generating code for class.idl."

--- a/test/class/class-impl.cc
+++ b/test/class/class-impl.cc
@@ -1,11 +1,44 @@
-#include <stdio.h>
 #include "class-impl.h"
 
-JSClassExample::JSClassExample() {}
+struct value__ {
+  value__(unsigned long initial): val(initial) {}
+  unsigned long val = 0;
+  size_t refcount = 1;
+  inline void Ref() { refcount++; }
+  inline void Unref() {
+    if (refcount == 0) abort();
+    if (--refcount == 0) delete this;
+  }
+};
 
-JSClassExample::JSClassExample(unsigned long initial): value(initial) {}
+void Decrementor::operator=(const Decrementor& other) {
+  val = other.val;
+  val->Ref();
+}
 
-JSClassExample::JSClassExample(DOMString initial):
-    value(std::stoul(initial)) {}
+Decrementor::Decrementor() {}
 
-unsigned long JSClassExample::increment() { return ++value; }
+Decrementor::Decrementor(const Incrementor& inc) {
+  val = inc.val;
+  val->Ref();
+}
+
+Decrementor::~Decrementor() { val->Unref(); }
+
+unsigned long Decrementor::decrement() { return --(val->val); }
+
+Incrementor::Incrementor(): Incrementor(0) {}
+
+Incrementor::Incrementor(DOMString initial_value)
+    : Incrementor(std::stoul(initial_value)) {}
+
+Incrementor::Incrementor(unsigned long initial_value) {
+  val = new value__(initial_value);
+  val->val = initial_value;
+}
+
+unsigned long Incrementor::increment() { return ++(val->val); }
+
+Decrementor Incrementor::getDecrementor() { return Decrementor(*this); }
+
+Incrementor::~Incrementor() { val->Unref(); }

--- a/test/class/class-impl.h
+++ b/test/class/class-impl.h
@@ -3,14 +3,31 @@
 
 #include "webidl-napi.h"
 
-class JSClassExample {
+typedef struct value__* Value;
+class Incrementor;
+
+class Decrementor {
  public:
-  explicit JSClassExample();
-  JSClassExample(unsigned long initial);
-  JSClassExample(DOMString initial);
-  unsigned long increment();
+  void operator=(const Decrementor& other);
+  Decrementor();
+  Decrementor(const Incrementor& inc);
+  ~Decrementor();
+  unsigned long decrement();
  private:
-  unsigned long value = 0;
+  Value val = nullptr;
+};
+
+class Incrementor {
+ public:
+  explicit Incrementor();
+  Incrementor(unsigned long initial);
+  Incrementor(DOMString initial);
+  unsigned long increment();
+  Decrementor getDecrementor();
+  friend class Decrementor;
+  ~Incrementor();
+ private:
+  Value val;
 };
 
 #endif  // WEBIDL_NAPI_TEST_WEBIDL2_EXAMPLE_EXAMPLE_IMPL_H

--- a/test/class/class.idl
+++ b/test/class/class.idl
@@ -1,6 +1,12 @@
-interface JSClassExample {
+interface Decrementor {
+  constructor(Incrementor incrementor);
+  unsigned long decrement();
+};
+
+interface Incrementor {
   constructor();
   constructor(unsigned long initial);
   constructor(DOMString initial);
   unsigned long increment();
+  Decrementor getDecrementor();
 };

--- a/test/class/test.js
+++ b/test/class/test.js
@@ -4,7 +4,21 @@ const assert = require('assert');
 test(require('bindings')({ bindings: 'class', module_root: __dirname }));
 
 function test(binding) {
-  assert.strictEqual((new binding.JSClassExample(12)).increment(), 13);
-  assert.strictEqual((new binding.JSClassExample()).increment(), 1);
-  assert.strictEqual((new binding.JSClassExample('5')).increment(), 6);
+  {
+    assert.strictEqual((new binding.Incrementor(12)).increment(), 13);
+    assert.strictEqual((new binding.Incrementor()).increment(), 1);
+    assert.strictEqual((new binding.Incrementor('5')).increment(), 6);
+  }
+  {
+    const inc = new binding.Incrementor(39);
+    const dec = inc.getDecrementor();
+    assert.strictEqual(inc.increment(), 40);
+    assert.strictEqual(dec.decrement(), 39);
+  }
+  global.gc();
+  global.gc();
+  global.gc();
+
+  // Give the gc time to act.
+  setTimeout(() => {}, 1000);
 }

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,10 @@ const path = require('path');
 readdirSync(__dirname).forEach((item) => {
   const testDir = path.join(__dirname, item);
   if (lstatSync(testDir).isDirectory()) {
-    const child = spawnSync(process.execPath, [path.join(testDir, 'test.js')], {
+    const child = spawnSync(process.execPath, [
+      '--expose-gc',
+      path.join(testDir, 'test.js')
+    ], {
       stdio: 'inherit'
     });
     if (child.signal || child.status != 0) {

--- a/test/webgpu/CMakeLists.txt
+++ b/test/webgpu/CMakeLists.txt
@@ -14,7 +14,7 @@ execute_process(
 )
 string(REPLACE "\n" "" REPO_ROOT ${REPO_ROOT})
 add_custom_command(
-    COMMAND node ${REPO_ROOT}/index.js -i webgpu-impl.h -n node_api.h -o ${CMAKE_CURRENT_BINARY_DIR}/webgpu.cc ${CMAKE_CURRENT_SOURCE_DIR}/webgpu.idl
+    COMMAND node ${REPO_ROOT}/index.js -i webgpu-impl.h -o ${CMAKE_CURRENT_BINARY_DIR}/webgpu.cc ${CMAKE_CURRENT_SOURCE_DIR}/webgpu.idl
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/webgpu.idl ${REPO_ROOT}/index.js
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/webgpu.cc
     COMMENT "Generating code for webgpu.idl."

--- a/test/webgpu/webgpu-impl.h
+++ b/test/webgpu/webgpu-impl.h
@@ -1,7 +1,7 @@
 #ifndef WEBIDL_NAPI_TEST_WEBGPU_WEBGPU_IMPL_H
 #define WEBIDL_NAPI_TEST_WEBGPU_WEBGPU_IMPL_H
 
-#include "webidl-napi-inl.h"
+#include "webidl-napi.h"
 
 enum GPUPowerPreference {
   Low_power,

--- a/test/webidl2_example/CMakeLists.txt
+++ b/test/webidl2_example/CMakeLists.txt
@@ -14,7 +14,7 @@ execute_process(
 )
 string(REPLACE "\n" "" REPO_ROOT ${REPO_ROOT})
 add_custom_command(
-    COMMAND node ${REPO_ROOT}/index.js -i example-impl.h -n node_api.h -o ${CMAKE_CURRENT_BINARY_DIR}/example.cc ${CMAKE_CURRENT_SOURCE_DIR}/example.idl
+    COMMAND node ${REPO_ROOT}/index.js -i example-impl.h -o ${CMAKE_CURRENT_BINARY_DIR}/example.cc ${CMAKE_CURRENT_SOURCE_DIR}/example.idl
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/example.idl ${REPO_ROOT}/index.js
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/example.cc
     COMMENT "Generating code for example.idl."

--- a/test/webidl2_example/example-impl.h
+++ b/test/webidl2_example/example-impl.h
@@ -2,7 +2,7 @@
 #define WEBIDL_NAPI_TEST_WEBIDL2_EXAMPLE_EXAMPLE_IMPL_H
 
 #include <string>
-#include "webidl-napi-inl.h"
+#include "webidl-napi.h"
 
 class WebIDLCompiler {
  public:

--- a/webidl-napi.h
+++ b/webidl-napi.h
@@ -1,13 +1,15 @@
-#ifndef WEBIDL_NAPI
-#define WEBIDL_NAPI
+#ifndef WEBIDL_NAPI_H
+#define WEBIDL_NAPI_H
 
 #include <string.h>
 #include <string>
+#include <map>
 #include <memory>
 #include <vector>
 
 // TODO(gabrielschulhof): Once we no longer support Node.js 10, we can
 // unconditionally switch to the js_native_api.h header.
+#define NAPI_EXPERIMENTAL
 #if defined(BUILDING_NODE_EXTENSION)
 #include "node_api.h"
 #else
@@ -113,8 +115,24 @@ class sequence {
   ToNative(napi_env env, napi_value val, sequence<T>* result);
 };
 
+class InstanceData {
+ public:
+  static napi_status GetCurrent(napi_env env, InstanceData** result);
+  void AddConstructor(const char* name, napi_ref ctor);
+  napi_ref GetConstructor(const char* name);
+  void SetData(void* data, napi_finalize fin_cb, void* hint);
+  void* GetData();
+ private:
+  static void DestroyInstanceData(napi_env env, void* raw, void* hint);
+  void Destroy(napi_env env);
+  std::map<const char*, napi_ref> ctors;
+  void* data = nullptr;
+  void* hint = nullptr;
+  napi_finalize cb = nullptr;
+};
+
 }  // end of namespace WebIdlNapi
 
 #include "webidl-napi-inl.h"
 
-#endif  // WEBIDL_NAPI
+#endif  // WEBIDL_NAPI_H


### PR DESCRIPTION
This implements methods of the form

```JS
const x = (new Y()).methodReturnsNewX();
```

Where `X` and `Y` are JS classes. IOW this implements constructing an
instance of a JS class from native.

The test also illustrates how multiple JS objects can refer to the same
native object using a refcounting approach for ensuring the native
object is freed only after all JS objects that refer to it have been
garbage-collected.